### PR TITLE
Sync forked Bridge with Arduino official changes

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,0 +1,24 @@
+= Bridge Library for Arduino =
+
+The Bridge library simplifies communication between the ATmega32U4 and the AR9331.
+
+For more information about this library please visit us at
+http://arduino.cc/en/Reference/YunBridgeLibrary
+
+== License ==
+
+Copyright (c) 2014 Arduino LLC. All right reserved.
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA

--- a/keywords.txt
+++ b/keywords.txt
@@ -6,15 +6,15 @@
 # Class (KEYWORD1)
 #######################################
 
-Bridge	KEYWORD1
-FileIO	KEYWORD4
-FileSystem	KEYWORD1
-Console	KEYWORD1
-Process	KEYWORD1
-Mailbox	KEYWORD1
-HttpClient	KEYWORD1
-YunServer	KEYWORD1
-YunClient	KEYWORD1
+Bridge	KEYWORD1	YunBridgeLibrary
+FileIO	KEYWORD4	YunFileIOConstructor
+FileSystem	KEYWORD1	YunFileIOConstructor
+Console	KEYWORD1	YunConsoleConstructor
+Process	KEYWORD1	YunProcessConstructor
+Mailbox	KEYWORD1	YunMailboxConstructor
+HttpClient	KEYWORD1	YunHttpClientConstructor
+YunServer	KEYWORD1	YunServerConstructor
+YunClient	KEYWORD1	YunClientConstructor
 
 #######################################
 # Methods and Functions (KEYWORD2)

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Bridge
-version=1.0.2
+version=1.0.5
 author=Arduino
 maintainer=Arduino <info@arduino.cc>
 sentence=Enables the communication between the Linux processor and the AVR. Originally developed for Arduino Yún and TRE.

--- a/src/Bridge.h
+++ b/src/Bridge.h
@@ -19,6 +19,10 @@
 #ifndef BRIDGE_H_
 #define BRIDGE_H_
 
+#ifndef BRIDGE_BAUDRATE
+#define BRIDGE_BAUDRATE 250000
+#endif
+
 #include <Arduino.h>
 #include <Stream.h>
 
@@ -96,7 +100,7 @@ class SerialBridgeClass : public BridgeClass {
       // Empty
     }
 
-    void begin(unsigned long baudrate = 250000) {
+    void begin(unsigned long baudrate = BRIDGE_BAUDRATE) {
       serial->begin(baudrate);
       BridgeClass::begin();
     }
@@ -108,7 +112,7 @@ class SerialBridgeClass : public BridgeClass {
       BridgeClass::begin();
     }
 
-    void begin(HardwareSerial &_serial, unsigned long baudrate = 250000) {
+    void begin(HardwareSerial &_serial, unsigned long baudrate = BRIDGE_BAUDRATE) {
       serial = &_serial;
       serial->begin(baudrate);
       stream = &_serial;


### PR DESCRIPTION
Most of the changes are of cosmetic nature (new scheme for keywords, etc.), the only real difference is that Arduino accepted https://github.com/arduino/Arduino/commit/f118dee6882343a70c1b1793335e0d6eec37449a - allowing to specify the baud rate by 

```
#define BRIDGE_BAUDRATE 57600
```

before including `Bridge.h`
